### PR TITLE
Add initial React Native mental health app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import WelcomeScreen from './src/components/WelcomeScreen';
+import QuestionScreen from './src/components/QuestionScreen';
+import ResultScreen from './src/components/ResultScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
+        <Stack.Screen name="Questionnaire" component={QuestionScreen} />
+        <Stack.Screen name="Result" component={ResultScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# portal-emocional
+# Portal Emocional
+
+Aplicativo de avaliação de saúde mental contendo os instrumentos PHQ-9, GAD-7 e DASS-21.
+
+## Requisitos
+- Node.js 20+
+- Yarn ou npm
+- Expo CLI (`npm install -g expo-cli`)
+
+## Instalação
+```bash
+npm install
+```
+
+## Uso
+```bash
+npm start
+```
+Abra o aplicativo Expo Go em um dispositivo iOS ou Android e escaneie o QR code para rodar o app.
+
+## Estrutura
+- `App.js` — ponto de entrada com React Navigation.
+- `src/data/questionnaires.js` — textos das perguntas.
+- `src/utils/scoring.js` — lógica de cálculo e interpretação dos escores.
+
+## Testes
+Atualmente não há testes automatizados. Adicione testes unitários para as funções de `src/utils/scoring.js` conforme necessário.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "portal-emocional",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "0.73.0",
+    "expo": "^49.0.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  }
+}

--- a/src/components/QuestionScreen.js
+++ b/src/components/QuestionScreen.js
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { PHQ9_QUESTIONS, GAD7_QUESTIONS, DASS21_QUESTIONS } from '../data/questionnaires';
+import { scorePHQ9, scoreGAD7, scoreDASS21 } from '../utils/scoring';
+
+export default function QuestionScreen({ route, navigation }) {
+  const { type } = route.params;
+  const questions = type === 'PHQ9' ? PHQ9_QUESTIONS : type === 'GAD7' ? GAD7_QUESTIONS : DASS21_QUESTIONS;
+  const [index, setIndex] = useState(0);
+  const [answers, setAnswers] = useState(Array(questions.length).fill(0));
+
+  const next = value => {
+    const updated = [...answers];
+    updated[index] = value;
+    if (index + 1 < questions.length) {
+      setAnswers(updated);
+      setIndex(index + 1);
+    } else {
+      finish(updated);
+    }
+  };
+
+  const back = () => index > 0 && setIndex(index - 1);
+
+  const finish = allAnswers => {
+    let result;
+    if (type === 'PHQ9') result = scorePHQ9(allAnswers);
+    else if (type === 'GAD7') result = scoreGAD7(allAnswers);
+    else result = scoreDASS21(allAnswers);
+    navigation.navigate('Result', { type, result });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.progress}>{`Question ${index + 1} of ${questions.length}`}</Text>
+      <Text style={styles.question}>{questions[index]}</Text>
+      <View style={styles.row}>
+        {[0,1,2,3].map(val => (
+          <Button key={val} title={String(val)} onPress={() => next(val)} />
+        ))}
+      </View>
+      <Button title="Back" onPress={back} disabled={index === 0} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20 },
+  progress: { textAlign: 'center', marginBottom: 20 },
+  question: { fontSize: 18, marginBottom: 20 },
+  row: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 20 }
+});

--- a/src/components/ResultScreen.js
+++ b/src/components/ResultScreen.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function ResultScreen({ route, navigation }) {
+  const { type, result } = route.params;
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Results for {type}</Text>
+      {type === 'DASS21' ? (
+        <View>
+          <Text>Depression: {result.totals.depression} ({result.categories.depression})</Text>
+          <Text>Anxiety: {result.totals.anxiety} ({result.categories.anxiety})</Text>
+          <Text>Stress: {result.totals.stress} ({result.categories.stress})</Text>
+        </View>
+      ) : (
+        <Text>Score: {result.total} ({result.category})</Text>
+      )}
+      <Button title="Start Over" onPress={() => navigation.popToTop()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  title: { fontSize: 24, marginBottom: 20 }
+});

--- a/src/components/WelcomeScreen.js
+++ b/src/components/WelcomeScreen.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function WelcomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Mental Health Assessment</Text>
+      <Text style={styles.text}>Please select the questionnaire you wish to answer.</Text>
+      <Button title="PHQ-9" onPress={() => navigation.navigate('Questionnaire', { type: 'PHQ9' })} />
+      <Button title="GAD-7" onPress={() => navigation.navigate('Questionnaire', { type: 'GAD7' })} />
+      <Button title="DASS-21" onPress={() => navigation.navigate('Questionnaire', { type: 'DASS21' })} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  title: { fontSize: 24, marginBottom: 20 },
+  text: { textAlign: 'center', marginBottom: 20 },
+});

--- a/src/data/questionnaires.js
+++ b/src/data/questionnaires.js
@@ -1,0 +1,51 @@
+export const PHQ9_QUESTIONS = [
+  "Little interest or pleasure in doing things",
+  "Feeling down, depressed, or hopeless",
+  "Trouble falling or staying asleep, or sleeping too much",
+  "Feeling tired or having little energy",
+  "Poor appetite or overeating",
+  "Feeling bad about yourself or that you are a failure",
+  "Trouble concentrating on things, such as reading or watching TV",
+  "Moving or speaking slowly, or being fidgety or restless",
+  "Thoughts that you would be better off dead or hurting yourself"
+];
+
+export const GAD7_QUESTIONS = [
+  "Feeling nervous, anxious, or on edge",
+  "Not being able to stop or control worrying",
+  "Worrying too much about different things",
+  "Trouble relaxing",
+  "Being so restless that it's hard to sit still",
+  "Becoming easily annoyed or irritable",
+  "Feeling afraid as if something awful might happen"
+];
+
+export const DASS21_QUESTIONS = [
+  "I found it hard to wind down",
+  "I was aware of dryness of my mouth",
+  "I couldn't seem to experience any positive feeling at all",
+  "I experienced breathing difficulty",
+  "I found it difficult to work up the initiative to do things",
+  "I tended to over-react to situations",
+  "I experienced trembling",
+  "I felt that I was using a lot of nervous energy",
+  "I was worried about situations in which I might panic",
+  "I felt that I had nothing to look forward to",
+  "I found myself getting agitated",
+  "I found it difficult to relax",
+  "I felt down-hearted and blue",
+  "I was intolerant of anything that kept me from getting on",
+  "I felt I was close to panic",
+  "I was unable to become enthusiastic about anything",
+  "I felt I wasn't worth much as a person",
+  "I felt that I was rather touchy",
+  "I was aware of the action of my heart in the absence of physical exertion",
+  "I felt scared without any good reason",
+  "I felt that life was meaningless"
+];
+
+export const DASS21_MAP = {
+  depression: [2,4,9,12,15,16,20],
+  anxiety: [1,3,6,8,14,18,19],
+  stress: [0,5,7,10,11,13,17]
+};

--- a/src/utils/scoring.js
+++ b/src/utils/scoring.js
@@ -1,0 +1,49 @@
+export function scorePHQ9(answers) {
+  const total = answers.reduce((sum, val) => sum + val, 0);
+  let category = '';
+  if (total <= 4) category = 'minimal';
+  else if (total <= 9) category = 'mild';
+  else if (total <= 14) category = 'moderate';
+  else if (total <= 19) category = 'moderately severe';
+  else category = 'severe';
+  return { total, category };
+}
+
+export function scoreGAD7(answers) {
+  const total = answers.reduce((sum, val) => sum + val, 0);
+  let category = '';
+  if (total <= 4) category = 'minimal';
+  else if (total <= 9) category = 'mild';
+  else if (total <= 14) category = 'moderate';
+  else category = 'severe';
+  return { total, category };
+}
+
+export function scoreDASS21(answers) {
+  const subscaleTotals = { depression: 0, anxiety: 0, stress: 0 };
+  const subscaleMap = {
+    depression: [2,4,9,12,15,16,20],
+    anxiety: [1,3,6,8,14,18,19],
+    stress: [0,5,7,10,11,13,17],
+  };
+  Object.keys(subscaleMap).forEach(key => {
+    subscaleMap[key].forEach(index => {
+      subscaleTotals[key] += answers[index] || 0;
+    });
+    subscaleTotals[key] *= 2; // DASS-21 convention
+  });
+  const categories = {
+    depression: categorizeDASS(subscaleTotals.depression, [9,13,20,27]),
+    anxiety: categorizeDASS(subscaleTotals.anxiety, [7,9,14,19]),
+    stress: categorizeDASS(subscaleTotals.stress, [14,18,25,33])
+  };
+  return { totals: subscaleTotals, categories };
+}
+
+function categorizeDASS(score, thresholds) {
+  if (score <= thresholds[0]) return 'normal';
+  if (score <= thresholds[1]) return 'mild';
+  if (score <= thresholds[2]) return 'moderate';
+  if (score <= thresholds[3]) return 'severe';
+  return 'extremely severe';
+}


### PR DESCRIPTION
## Summary
- bootstrap Expo app with PHQ‑9, GAD‑7 and DASS‑21 questionnaires
- implement scoring utilities and minimal screens
- provide basic README instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872bce641f48332923f936a55e0151b

## Summary by Sourcery

Bootstrap a new Expo-based React Native mental health assessment app featuring PHQ-9, GAD-7, and DASS-21 questionnaires with navigation, scoring, and results display.

New Features:
- Add questionnaire data and scoring logic for PHQ-9, GAD-7, and DASS-21
- Implement navigation flow with Welcome, Question, and Result screens

Enhancements:
- Build reusable scoring utilities to categorize questionnaire results

Build:
- Initialize package.json with dependencies and Expo start script

Documentation:
- Add README with installation, usage, and project structure